### PR TITLE
Added improved methods for setting encoding options and pixel format

### DIFF
--- a/src/image_loader_avif.cpp
+++ b/src/image_loader_avif.cpp
@@ -68,6 +68,11 @@ Error ImageLoaderAVIF::avif_load_image_from_buffer(Image *p_image, const uint8_t
 	return OK;
 }
 
+Ref<Image> ImageLoaderAVIF::load_avif_from_buffer(PackedByteArray p_buffer) {
+	ERR_FAIL_COND_V(_avif_mem_loader_func == NULL, Ref<Image>());
+	return _avif_mem_loader_func(p_buffer.ptr(), p_buffer.size());
+}
+
 Error ImageLoaderAVIF::_load_image(const Ref<Image> &p_image, const Ref<FileAccess> &p_file, BitField<ImageFormatLoader::LoaderFlags> p_flags, double p_scale) {
 	ERR_FAIL_COND_V(p_file.is_null() || !p_file->is_open(), ERR_INVALID_PARAMETER);
 
@@ -97,6 +102,10 @@ Ref<Image> ImageLoaderAVIF::_avif_mem_loader_func(const uint8_t *p_buffer, int p
 	ERR_FAIL_COND_V(err, Ref<Image>());
 	avifDecoderDestroy(decoder);
 	return img;
+}
+
+void ImageLoaderAVIF::_bind_methods() {
+	ClassDB::bind_static_method("ImageLoaderAVIF", D_METHOD("load_avif_from_buffer", "avif_data"), &ImageLoaderAVIF::load_avif_from_buffer);
 }
 
 ImageLoaderAVIF::ImageLoaderAVIF() {

--- a/src/image_loader_avif.h
+++ b/src/image_loader_avif.h
@@ -38,7 +38,7 @@ class ImageLoaderAVIF : public godot::ImageFormatLoaderExtension {
 	GDCLASS(ImageLoaderAVIF, godot::ImageFormatLoaderExtension);
 
 protected:
-	static void _bind_methods() {}
+	static void _bind_methods();
 
 	static godot::Error avif_load_image_from_buffer(godot::Image *p_image, const uint8_t *p_buffer, int p_buffer_len, avifDecoder *p_decoder);
 	static godot::Ref<godot::Image> _avif_mem_loader_func(const uint8_t *p_buffer, int p_size);
@@ -46,6 +46,9 @@ protected:
 public:
 	virtual godot::Error _load_image(const godot::Ref<godot::Image> &p_image, const godot::Ref<godot::FileAccess> &p_file, godot::BitField<godot::ImageFormatLoader::LoaderFlags> p_flags, double p_scale) override;
 	virtual godot::PackedStringArray _get_recognized_extensions() const override;
+
+	static godot::Ref<godot::Image> load_avif_from_buffer(godot::PackedByteArray p_buffer);
+
 	ImageLoaderAVIF();
 };
 

--- a/src/resource_saver_avif.h
+++ b/src/resource_saver_avif.h
@@ -65,9 +65,12 @@ public:
 	virtual bool _recognize(const godot::Ref<godot::Resource> &p_resource) const override;
 	virtual godot::PackedStringArray _get_recognized_extensions(const godot::Ref<godot::Resource> &p_resource) const override;
 
-	static godot::Error save_image(godot::Ref<godot::Image> p_image, const godot::String &p_path, const godot::Dictionary &p_options = godot::Dictionary(), PixelFormat p_format = AVIF_PIXEL_DEFAULT);
-	static godot::PackedByteArray encode_image(godot::Ref<godot::Image> p_image, const godot::Dictionary &p_options = godot::Dictionary(), PixelFormat p_format = AVIF_PIXEL_DEFAULT);
-	static void set_defaults(const godot::Dictionary &p_options, PixelFormat p_format);
+	static godot::Error save_avif(godot::Ref<godot::Image> p_image, const godot::String &p_path, const godot::Dictionary &p_options = godot::Dictionary(), PixelFormat p_format = AVIF_PIXEL_YUV422);
+	static godot::PackedByteArray save_avif_to_buffer(godot::Ref<godot::Image> p_image, const godot::Dictionary &p_options = godot::Dictionary(), PixelFormat p_format = AVIF_PIXEL_YUV422);
+	static void set_avif_options_and_format(const godot::Dictionary &p_options = {}, PixelFormat p_format = AVIF_PIXEL_YUV422);
+	static void reset_avif_options_and_format();
+	static godot::Dictionary get_avif_encoder_options();
+	static PixelFormat get_avif_pixel_format();
 
 	ResourceSaverAVIF();
 	~ResourceSaverAVIF() { singleton = nullptr; }


### PR DESCRIPTION
Adds new methods `load_avif_from_buffer`, `reset_avif_options_and_format`, `get_avif_encoder_options` and `get_avif_pixel_format`, and renames `save_image` to `save_avif`; `encode_image` to `save_avif_to_buffer` and `set_defaults` to `set_avif_options_and_format`.

The renames are consistant with existing image saving methods such as `save_jpg`, `save_png`, etc.