### PR TITLE
Add initial documentation and added missing module build header include

### DIFF
--- a/doc_classes/ImageLoaderAVIF.xml
+++ b/doc_classes/ImageLoaderAVIF.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ImageLoaderAVIF" inherits="ImageFormatLoaderExtension" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		AVIF image format loading.
+	</brief_description>
+	<description>
+		[b]NOTE:[/b] To load an AVIF [Image] from a file, simply use [code]load("res://my_image_file.avif")[/code].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="load_avif_from_buffer" qualifiers="static">
+			<return type="Image" />
+			<param index="0" name="avif_data" type="PackedByteArray" />
+			<description>
+				Loads and returns an [Image] from a [PackedByteArray]. The [PackedByteArray] can be created using [method ResourceSaverAVIF.save_avif_to_buffer].
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc_classes/ResourceSaverAVIF.xml
+++ b/doc_classes/ResourceSaverAVIF.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceSaverAVIF" inherits="ResourceFormatSaver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		AVIF image format encoding and saving.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_avif_encoder_options" qualifiers="static">
+			<return type="Dictionary" />
+			<description>
+				Returns the currently set encoder options.
+			</description>
+		</method>
+		<method name="get_avif_pixel_format" qualifiers="static">
+			<return type="int" enum="ResourceSaverAVIF.PixelFormat" />
+			<description>
+				Returns the currently set [enum PixelFormat].
+			</description>
+		</method>
+		<method name="reset_avif_options_and_format" qualifiers="static">
+			<return type="void" />
+			<description>
+				Resets the encoder options and [enum PixelFormat] to their original, factory settings.
+			</description>
+		</method>
+		<method name="save_avif" qualifiers="static">
+			<return type="int" enum="Error" />
+			<param index="0" name="image" type="Image" />
+			<param index="1" name="path" type="String" />
+			<param index="2" name="options" type="Dictionary" default="{}" />
+			<param index="3" name="format" type="int" enum="ResourceSaverAVIF.PixelFormat" default="2" />
+			<description>
+				Saves an [Image] to an AVIF file using the currently set encoder options and [enum PixelFormat], or via the optional parameters [param options] and [param format].
+			</description>
+		</method>
+		<method name="save_avif_to_buffer" qualifiers="static">
+			<return type="PackedByteArray" />
+			<param index="0" name="image" type="Image" />
+			<param index="1" name="options" type="Dictionary" default="{}" />
+			<param index="2" name="format" type="int" enum="ResourceSaverAVIF.PixelFormat" default="2" />
+			<description>
+				Saves an [Image] to a [PackedByteArray] using the currently set encoder options and [enum PixelFormat], or via the optional parameters [param options] and [param format].
+				The saved [PackedByteArray] can be reloaded as an [Image] using [method ImageLoaderAVIF.load_avif_from_buffer].
+			</description>
+		</method>
+		<method name="set_avif_options_and_format" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="options" type="Dictionary" default="{}" />
+			<param index="1" name="format" type="int" enum="ResourceSaverAVIF.PixelFormat" default="2" />
+			<description>
+				Sets the active encoder options and [enum PixelFormat]. Any number of option keys can be included in the [param options] argument. Any omitted keys will remain set at their current values.
+				Passing an invalid key will generate an error.
+				[b]NOTE:[/b] Use [method get_avif_encoder_options] to obtain a [Dictionary] with all of the possible valid option keys.
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="AVIF_PIXEL_DEFAULT" value="0" enum="PixelFormat">
+		</constant>
+		<constant name="AVIF_PIXEL_YUV444" value="1" enum="PixelFormat">
+		</constant>
+		<constant name="AVIF_PIXEL_YUV422" value="2" enum="PixelFormat">
+		</constant>
+		<constant name="AVIF_PIXEL_YUV420" value="3" enum="PixelFormat">
+		</constant>
+		<constant name="AVIF_PIXEL_YUV400" value="4" enum="PixelFormat">
+		</constant>
+	</constants>
+</class>

--- a/resource_saver_avif.cpp
+++ b/resource_saver_avif.cpp
@@ -38,6 +38,7 @@
 #include "core/io/file_access.h"
 #include "core/io/image.h"
 #include "core/templates/vector.h"
+#include "scene/resources/image_texture.h"
 #include "scene/resources/texture.h"
 
 #endif


### PR DESCRIPTION
The `image_texture.h` include seems not to have been required prior to Godot 4.2.